### PR TITLE
Add entry timestamp

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -149,7 +149,7 @@ target_link_libraries(cache_client
 ################################################################################
 project(cache_injector)
 
-find_package(Boost ${BOOST_VERSION} COMPONENTS program_options coroutine system REQUIRED)
+find_package(Boost ${BOOST_VERSION} COMPONENTS program_options date_time coroutine system REQUIRED)
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14 -pthread -Wall -ggdb ${SANITIZE}")
 
 include_directories(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -125,7 +125,7 @@ if(IPFS_CACHE_WITH_EXAMPLE_BINARIES)
 ################################################################################
 project(cache_client)
 
-find_package(Boost ${BOOST_VERSION} COMPONENTS program_options coroutine system REQUIRED)
+find_package(Boost ${BOOST_VERSION} COMPONENTS program_options date_time coroutine system REQUIRED)
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14 -pthread -Wall -ggdb ${SANITIZE}")
 
 include_directories(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,6 @@
 cmake_minimum_required (VERSION 3.5)
-set(GLOB BOOST_VERSION 1.55)
+# NOTE: from_iso_extended_string has been introduced in Boost 1.62
+set(BOOST_VERSION 1.62.0)
 include(ExternalProject)
 ################################################################################
 option(IPFS_CACHE_WITH_EXAMPLE_BINARIES "Build with example binaries" ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,9 @@ include(ExternalProject)
 ################################################################################
 option(IPFS_CACHE_WITH_EXAMPLE_BINARIES "Build with example binaries" ON)
 
+add_definitions(-DBOOST_COROUTINE_NO_DEPRECATION_WARNING
+                -DBOOST_COROUTINES_NO_DEPRECATION_WARNING)
+
 ################################################################################
 # TODO(peterj): Address sanitizer seems to cause segmentation faults on exit
 #               from main(?).

--- a/include/ipfs_cache/error.h
+++ b/include/ipfs_cache/error.h
@@ -19,6 +19,7 @@ namespace ipfs_cache { namespace error {
         db_download_failed,
         invalid_db_format,
         error_parsing_json,
+        malformed_db_entry,
     };
     
     struct ipfs_category : public boost::system::error_category
@@ -67,6 +68,8 @@ namespace ipfs_cache { namespace error {
                     return "invalid database format";
                 case error::error_parsing_json:
                     return "error parsing json";
+                case error::malformed_db_entry:
+                    return "malformed database entry";
                 default:
                     return "unknown ipfs_cache error";
             }

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -22,7 +22,8 @@ void Client::get_content(string url, function<void(sys::error_code, Json)> cb)
 
     sys::error_code ec;
 
-    string ipfs_id = _db->query(url, ec);
+    CacheEntry entry = _db->query(url, ec);
+    string ipfs_id = entry.link;
 
     if (!ec && ipfs_id.empty()) {
         ec = error::key_not_found;

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -23,9 +23,8 @@ void Client::get_content(string url, function<void(sys::error_code, Json)> cb)
     sys::error_code ec;
 
     CacheEntry entry = _db->query(url, ec);
-    string ipfs_id = entry.link;
 
-    if (!ec && ipfs_id.empty()) {
+    if (!ec && entry.date.is_not_a_date_time()) {
         ec = error::key_not_found;
     }
 
@@ -33,7 +32,7 @@ void Client::get_content(string url, function<void(sys::error_code, Json)> cb)
         return ios.post([cb = move(cb), ec] { cb(ec, Json()); });
     }
 
-    _backend->cat(ipfs_id, [cb = move(cb)] (sys::error_code ecc, string s) {
+    _backend->cat(entry.link, [cb = move(cb)] (sys::error_code ecc, string s) {
             if (ecc) {
                 return cb(ecc, move(s));
             }

--- a/src/db.cpp
+++ b/src/db.cpp
@@ -101,7 +101,11 @@ string now_as_string() {
 
 static
 boost::posix_time::ptime ptime_from_string(const string& s) {
-    return boost::posix_time::from_iso_extended_string(s);
+    try {
+        return boost::posix_time::from_iso_extended_string(s);
+    } catch(...) {
+        return boost::posix_time::ptime(boost::posix_time::not_a_date_time);
+    }
 }
 
 void InjectorDb::update(string key, string value, function<void(sys::error_code)> cb)

--- a/src/db.cpp
+++ b/src/db.cpp
@@ -3,6 +3,7 @@
 #include "republisher.h"
 
 #include <boost/asio/io_service.hpp>
+#include <boost/date_time/posix_time/posix_time.hpp>
 
 #include <ipfs_cache/error.h>
 
@@ -92,6 +93,12 @@ void initialize_db(Json& json, const string& ipns)
     json["sites"] = Json::object();
 }
 
+static
+string now_as_iso_string() {
+    auto entry_date = boost::posix_time::microsec_clock::universal_time();
+    return boost::posix_time::to_iso_extended_string(entry_date) + 'Z';
+}
+
 void InjectorDb::update(string key, string value, function<void(sys::error_code)> cb)
 {
     if (_local_db == Json()) {
@@ -104,7 +111,7 @@ void InjectorDb::update(string key, string value, function<void(sys::error_code)
     if (!key.empty()) {
         try {
             _local_db["sites"][key] = {
-                { "date", "<dummy>" },
+                { "date", now_as_iso_string() },
                 { "link", value }
             };
         }

--- a/src/db.cpp
+++ b/src/db.cpp
@@ -99,6 +99,11 @@ string now_as_string() {
     return boost::posix_time::to_iso_extended_string(entry_date) + 'Z';
 }
 
+static
+boost::posix_time::ptime ptime_from_string(const string& s) {
+    return boost::posix_time::from_iso_extended_string(s);
+}
+
 void InjectorDb::update(string key, string value, function<void(sys::error_code)> cb)
 {
     if (_local_db == Json()) {
@@ -191,6 +196,13 @@ static string query_(string key, const Json& db, sys::error_code& ec)
     // We only ever store objects with "date" and "link" members.
     if (item_i == sites_i->end() || !item_i->is_object()) {
         ec = make_error_code(error::key_not_found);
+        return "";
+    }
+
+    auto date_i = item_i->find("date");
+
+    if (date_i == item_i->end() || !date_i->is_string() || ptime_from_string(*date_i).is_not_a_date_time()) {
+        ec = make_error_code(error::malformed_db_entry);
         return "";
     }
 

--- a/src/db.cpp
+++ b/src/db.cpp
@@ -94,7 +94,7 @@ void initialize_db(Json& json, const string& ipns)
 }
 
 static
-string now_as_iso_string() {
+string now_as_string() {
     auto entry_date = boost::posix_time::microsec_clock::universal_time();
     return boost::posix_time::to_iso_extended_string(entry_date) + 'Z';
 }
@@ -111,7 +111,7 @@ void InjectorDb::update(string key, string value, function<void(sys::error_code)
     if (!key.empty()) {
         try {
             _local_db["sites"][key] = {
-                { "date", now_as_iso_string() },
+                { "date", now_as_string() },
                 { "link", value }
             };
         }

--- a/src/db.h
+++ b/src/db.h
@@ -3,6 +3,7 @@
 #include <boost/system/error_code.hpp>
 #include <boost/asio/spawn.hpp>
 #include <boost/asio/steady_timer.hpp>
+#include <boost/date_time/posix_time/posix_time.hpp>
 #include <string>
 #include <queue>
 #include <list>
@@ -21,13 +22,20 @@ class Backend;
 class Republisher;
 using Json = nlohmann::json;
 
+struct CacheEntry {
+    // Entry time stamp, not a date/time for missing or invalid entries.
+    boost::posix_time::ptime date;
+    // Entry value, empty for missing or invalid entries.
+    std::string link;
+};
+
 class ClientDb {
     using OnDbUpdate = std::function<void(const sys::error_code&)>;
 
 public:
     ClientDb(Backend&, std::string path_to_repo, std::string ipns);
 
-    std::string query(std::string key, sys::error_code& ec);
+    CacheEntry query(std::string key, sys::error_code& ec);
 
     boost::asio::io_service& get_io_service();
 
@@ -65,7 +73,7 @@ public:
     void update( std::string key, std::string value
                , std::function<void(sys::error_code)>);
 
-    std::string query(std::string key, sys::error_code& ec);
+    CacheEntry query(std::string key, sys::error_code& ec);
 
     boost::asio::io_service& get_io_service();
 

--- a/src/db.h
+++ b/src/db.h
@@ -25,7 +25,7 @@ using Json = nlohmann::json;
 struct CacheEntry {
     // Entry time stamp, not a date/time for missing or invalid entries.
     boost::posix_time::ptime date;
-    // Entry value, empty for missing or invalid entries.
+    // Entry value.
     std::string link;
 };
 


### PR DESCRIPTION
This adds support for a time stamp in each cache entry, so that one can spot entries which are too old to be used, or even too old to keep in the database, regardless of whether the linked content is still available.