### PR TITLE
Add entry links

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,11 +74,11 @@ https://ipfs.io/ipns/<DATABASE IPNS>
 Which may look something like this:
 
 ```
-{"my_key":"<IPFS CONTENT ID>"}
+{"my_key": {"date": "<INSERTION DATE>", "links": ["ipfs:/ipfs/<IPFS CONTENT ID>"]}}
 ```
 
 Note that the _value_ is not stored in the database directly, instead, it can be found
-in the IPFS network under `<IPFS CONTENT ID>`. We can again look it up with our
+in the IPFS network under `/ipfs/<IPFS CONTENT ID>`. We can again look it up with our
 browser by following the link
 
 ```

--- a/example/client.cpp
+++ b/example/client.cpp
@@ -64,9 +64,10 @@ int main(int argc, const char** argv)
                 client.wait_for_db_update(yield);
 
                 cout << "Fetching..." << endl;
-                ipfs_cache::Json value = client.get_content(key, yield);
+                ipfs_cache::CachedContent value = client.get_content(key, yield);
 
-                cout << "Value: " << value.dump() << endl;
+                cout << "Date: " << value.date << endl
+                     << "Value: " << value.data.dump() << endl;
             }
             catch (const exception& e) {
                 cerr << "Error: " << e.what() << endl;

--- a/include/ipfs_cache/client.h
+++ b/include/ipfs_cache/client.h
@@ -2,6 +2,7 @@
 
 #include <boost/asio/spawn.hpp>
 #include <boost/system/error_code.hpp>
+#include <boost/date_time/posix_time/posix_time.hpp>
 #include <functional>
 #include <memory>
 #include <string>
@@ -17,6 +18,13 @@ struct Backend;
 struct ClientDb;
 using Json = nlohmann::json;
 
+struct CachedContent {
+    // Data time stamp, not a date/time on errors.
+    boost::posix_time::ptime date;
+    // Cached data.
+    Json data;
+};
+
 class Client {
 public:
     Client(boost::asio::io_service&, std::string ipns, std::string path_to_repo);
@@ -31,9 +39,9 @@ public:
     // correspoinding to the `url`, when found, fetch the content corresponding
     // to that IPFS_ID from IPFS.
     void get_content( std::string url
-                    , std::function<void(boost::system::error_code, Json)>);
+                    , std::function<void(boost::system::error_code, CachedContent)>);
 
-    Json get_content(std::string url, boost::asio::yield_context);
+    CachedContent get_content(std::string url, boost::asio::yield_context);
 
     void wait_for_db_update(boost::asio::yield_context);
 

--- a/include/ipfs_cache/error.h
+++ b/include/ipfs_cache/error.h
@@ -20,6 +20,7 @@ namespace ipfs_cache { namespace error {
         invalid_db_format,
         error_parsing_json,
         malformed_db_entry,
+        missing_ipfs_link,
     };
     
     struct ipfs_category : public boost::system::error_category
@@ -70,6 +71,8 @@ namespace ipfs_cache { namespace error {
                     return "error parsing json";
                 case error::malformed_db_entry:
                     return "malformed database entry";
+                case error::missing_ipfs_link:
+                    return "missing IPFS link to content";
                 default:
                     return "unknown ipfs_cache error";
             }

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -32,7 +32,7 @@ void Client::get_content(string url, function<void(sys::error_code, Json)> cb)
         return ios.post([cb = move(cb), ec] { cb(ec, Json()); });
     }
 
-    _backend->cat(entry.link, [cb = move(cb)] (sys::error_code ecc, string s) {
+    _backend->cat(entry.content_hash, [cb = move(cb)] (sys::error_code ecc, string s) {
             if (ecc) {
                 return cb(ecc, move(s));
             }

--- a/src/db.cpp
+++ b/src/db.cpp
@@ -221,7 +221,7 @@ static CacheEntry query_(string key, const Json& db, sys::error_code& ec)
     }
 
     entry.date = date;
-    entry.link = *link_i;
+    entry.content_hash = *link_i;
     return entry;
 }
 

--- a/src/db.cpp
+++ b/src/db.cpp
@@ -107,7 +107,7 @@ boost::posix_time::ptime ptime_from_string(const string& s) {
     }
 }
 
-void InjectorDb::update(string key, string value, function<void(sys::error_code)> cb)
+void InjectorDb::update(string key, string content_hash, function<void(sys::error_code)> cb)
 {
     if (_local_db == Json()) {
         initialize_db(_local_db, _ipns);
@@ -120,7 +120,7 @@ void InjectorDb::update(string key, string value, function<void(sys::error_code)
         try {
             _local_db["sites"][key] = {
                 { "date", now_as_string() },
-                { "link", value }
+                { "link", content_hash }
             };
         }
         catch(...) {

--- a/src/db.cpp
+++ b/src/db.cpp
@@ -6,6 +6,7 @@
 
 #include <ipfs_cache/error.h>
 
+#include <algorithm>
 #include <fstream>
 
 using namespace std;
@@ -107,6 +108,8 @@ boost::posix_time::ptime ptime_from_string(const string& s) {
     }
 }
 
+const string ipfs_uri_prefix = "ipfs:/ipfs/";
+
 void InjectorDb::update(string key, string content_hash, function<void(sys::error_code)> cb)
 {
     if (_local_db == Json()) {
@@ -120,7 +123,7 @@ void InjectorDb::update(string key, string content_hash, function<void(sys::erro
         try {
             _local_db["sites"][key] = {
                 { "date", now_as_string() },
-                { "link", content_hash }
+                { "links", { ipfs_uri_prefix + content_hash } }
             };
         }
         catch(...) {
@@ -198,7 +201,7 @@ static CacheEntry query_(string key, const Json& db, sys::error_code& ec)
 
     auto item_i = sites_i->find(key);
 
-    // We only ever store objects with "date" and "link" members.
+    // We only ever store objects with "date" and "links" members.
     if (item_i == sites_i->end() || !item_i->is_object()) {
         ec = make_error_code(error::key_not_found);
         return entry;
@@ -206,22 +209,38 @@ static CacheEntry query_(string key, const Json& db, sys::error_code& ec)
 
     auto date_i = item_i->find("date");
 
+    // Get and parse the date string.
     boost::posix_time::ptime date;
     if (date_i == item_i->end() || !date_i->is_string() || (date = ptime_from_string(*date_i)).is_not_a_date_time()) {
         ec = make_error_code(error::malformed_db_entry);
         return entry;
     }
 
-    auto link_i = item_i->find("link");
+    auto links_i = item_i->find("links");
 
-    // We only ever store string values.
-    if (link_i == item_i->end() || !link_i->is_string()) {
+    // An array of strings (link URIs) is expected here.
+    if (links_i == item_i->end() || !links_i->is_array()) {
         ec = make_error_code(error::malformed_db_entry);
         return entry;
     }
 
+    // Look for the first item with the IPFS URI prefix.
+    auto link_i = find_if(links_i->begin(), links_i->end(), [](auto item) -> bool {
+            if (!item.is_string())
+                return false;
+            string link = item;
+            return link.find(ipfs_uri_prefix) == 0;
+        }
+    );
+    // There should be at least one IPFS link.
+    if (link_i == links_i->end()) {
+        ec = make_error_code(error::malformed_db_entry);
+        return entry;
+    }
+    string link = *link_i;
+
     entry.date = date;
-    entry.content_hash = *link_i;
+    entry.content_hash = link.substr(ipfs_uri_prefix.size());  // drop prefix, keep hash
     return entry;
 }
 

--- a/src/db.cpp
+++ b/src/db.cpp
@@ -234,7 +234,7 @@ static CacheEntry query_(string key, const Json& db, sys::error_code& ec)
     );
     // There should be at least one IPFS link.
     if (link_i == links_i->end()) {
-        ec = make_error_code(error::malformed_db_entry);
+        ec = make_error_code(error::missing_ipfs_link);
         return entry;
     }
     string link = *link_i;

--- a/src/db.h
+++ b/src/db.h
@@ -70,7 +70,7 @@ class InjectorDb {
 public:
     InjectorDb(Backend&, std::string path_to_repo);
 
-    void update( std::string key, std::string value
+    void update( std::string key, std::string content_hash
                , std::function<void(sys::error_code)>);
 
     CacheEntry query(std::string key, sys::error_code& ec);

--- a/src/db.h
+++ b/src/db.h
@@ -25,8 +25,8 @@ using Json = nlohmann::json;
 struct CacheEntry {
     // Entry time stamp, not a date/time for missing or invalid entries.
     boost::posix_time::ptime date;
-    // Entry value.
-    std::string link;
+    // Entry value (IPFS content hash).
+    std::string content_hash;
 };
 
 class ClientDb {


### PR DESCRIPTION
This extends the database format to support content stored on different systems, by means of replacing the plain IPFS content hash with a list of URI links to potentially multiple systems.

Since this is an IPFS-only library, we only produce one ``ipfs:/ipfs/...`` link in the list and we assume that there is always at least one such link when querying the db, from whence we extract the plain content hash (otherwise an error is produced). As a result, the API is not changed at all, only the storage format.

An example entry:

```json
"my_key6": {
    "date":"2018-01-19T18:50:39.802292Z",
    "links":["ipfs:/ipfs/QmWZbzd293NLjU9UsaqudPNXEPvtespKmPxCVKFHSFCaBV"]
}
```