### PR TITLE
Rename "date" entry members to "ts"

### DIFF
--- a/example/client.cpp
+++ b/example/client.cpp
@@ -66,7 +66,7 @@ int main(int argc, const char** argv)
                 cout << "Fetching..." << endl;
                 ipfs_cache::CachedContent value = client.get_content(key, yield);
 
-                cout << "Date: " << value.date << endl
+                cout << "Time stamp: " << value.ts << endl
                      << "Value: " << value.data.dump() << endl;
             }
             catch (const exception& e) {

--- a/include/ipfs_cache/client.h
+++ b/include/ipfs_cache/client.h
@@ -20,7 +20,7 @@ using Json = nlohmann::json;
 
 struct CachedContent {
     // Data time stamp, not a date/time on errors.
-    boost::posix_time::ptime date;
+    boost::posix_time::ptime ts;
     // Cached data.
     Json data;
 };

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -24,7 +24,7 @@ void Client::get_content(string url, function<void(sys::error_code, CachedConten
 
     CacheEntry entry = _db->query(url, ec);
 
-    if (!ec && entry.date.is_not_a_date_time()) {
+    if (!ec && entry.ts.is_not_a_date_time()) {
         ec = error::key_not_found;
     }
 
@@ -32,13 +32,13 @@ void Client::get_content(string url, function<void(sys::error_code, CachedConten
         return ios.post([cb = move(cb), ec] { cb(ec, CachedContent()); });
     }
 
-    _backend->cat(entry.content_hash, [cb = move(cb), date = entry.date] (sys::error_code ecc, string s) {
+    _backend->cat(entry.content_hash, [cb = move(cb), ts = entry.ts] (sys::error_code ecc, string s) {
             if (ecc) {
                 return cb(ecc, CachedContent());
             }
 
             try {
-                CachedContent cont({date, Json::parse(s)});
+                CachedContent cont({ts, Json::parse(s)});
                 cb(ecc, move(cont));
             }
             catch (...) {

--- a/src/db.h
+++ b/src/db.h
@@ -24,7 +24,7 @@ using Json = nlohmann::json;
 
 struct CacheEntry {
     // Entry time stamp, not a date/time for missing or invalid entries.
-    boost::posix_time::ptime date;
+    boost::posix_time::ptime ts;
     // Entry value (IPFS content hash).
     std::string content_hash;
 };


### PR DESCRIPTION
This renames ``date`` members in cache entries and in code to ``ts`` (for "timestamp") to better match their description and make them more different from ``data``.