### PR TITLE
Support arbitrary content instead of just JSON

### DIFF
--- a/example/client.cpp
+++ b/example/client.cpp
@@ -67,7 +67,7 @@ int main(int argc, const char** argv)
                 ipfs_cache::CachedContent value = client.get_content(key, yield);
 
                 cout << "Time stamp: " << value.ts << endl
-                     << "Value: " << value.data.dump() << endl;
+                     << "Value: " << value.data << endl;
             }
             catch (const exception& e) {
                 cerr << "Error: " << e.what() << endl;

--- a/include/ipfs_cache/client.h
+++ b/include/ipfs_cache/client.h
@@ -22,7 +22,7 @@ struct CachedContent {
     // Data time stamp, not a date/time on errors.
     boost::posix_time::ptime ts;
     // Cached data.
-    Json data;
+    std::string data;
 };
 
 class Client {

--- a/include/ipfs_cache/error.h
+++ b/include/ipfs_cache/error.h
@@ -18,7 +18,6 @@ namespace ipfs_cache { namespace error {
         key_not_found = 1, // Start with > 0, because 0 means success.
         db_download_failed,
         invalid_db_format,
-        error_parsing_json,
         malformed_db_entry,
         missing_ipfs_link,
     };
@@ -67,8 +66,6 @@ namespace ipfs_cache { namespace error {
                     return "database download failed";
                 case error::invalid_db_format:
                     return "invalid database format";
-                case error::error_parsing_json:
-                    return "error parsing json";
                 case error::malformed_db_entry:
                     return "malformed database entry";
                 case error::missing_ipfs_link:

--- a/include/ipfs_cache/injector.h
+++ b/include/ipfs_cache/injector.h
@@ -5,7 +5,6 @@
 #include <functional>
 #include <memory>
 #include <queue>
-#include <json.hpp>
 
 namespace boost { namespace asio {
     class io_service;
@@ -15,7 +14,6 @@ namespace ipfs_cache {
 
 struct Backend;
 struct InjectorDb;
-using Json = nlohmann::json;
 
 class Injector {
 public:
@@ -24,7 +22,7 @@ public:
 private:
     struct InsertEntry {
         std::string key;
-        Json        value;
+        std::string value;
         OnInsert    on_insert;
     };
 
@@ -46,11 +44,11 @@ public:
     // When testing or debugging, the content can be found here:
     // "https://ipfs.io/ipfs/" + <IPFS ID>
     void insert_content( std::string url
-                       , const Json& content
+                       , const std::string& content
                        , OnInsert);
 
     std::string insert_content( std::string url
-                              , const Json& content
+                              , const std::string& content
                               , boost::asio::yield_context);
 
     ~Injector();

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -37,13 +37,8 @@ void Client::get_content(string url, function<void(sys::error_code, CachedConten
                 return cb(ecc, CachedContent());
             }
 
-            try {
-                CachedContent cont({ts, Json::parse(s)});
-                cb(ecc, move(cont));
-            }
-            catch (...) {
-                cb(make_error_code(error::error_parsing_json), CachedContent());
-            }
+            CachedContent cont({ts, s});
+            cb(ecc, move(cont));
         });
 }
 

--- a/src/injector.cpp
+++ b/src/injector.cpp
@@ -33,7 +33,7 @@ void Injector::insert_content_from_queue()
     auto e = move(_insert_queue.front());
     _insert_queue.pop();
 
-    _backend->add( e.value.dump()
+    _backend->add( e.value
                  , [this, key = move(e.key), cb = move(e.on_insert)]
                    (sys::error_code eca, string ipfs_id) {
                         auto ipfs_id_ = ipfs_id;
@@ -53,7 +53,7 @@ void Injector::insert_content_from_queue()
                    });
 }
 
-void Injector::insert_content(string key, const Json& value, function<void(sys::error_code, string)> cb)
+void Injector::insert_content(string key, const string& value, function<void(sys::error_code, string)> cb)
 {
     _insert_queue.push(InsertEntry{move(key), move(value), move(cb)});
 
@@ -65,9 +65,8 @@ void Injector::insert_content(string key, const Json& value, function<void(sys::
     insert_content_from_queue();
 }
 
-string Injector::insert_content(string key, const Json& value, asio::yield_context yield)
+string Injector::insert_content(string key, const string& value, asio::yield_context yield)
 {
-    Json json_test = 1;
     using handler_type = typename asio::handler_type
                            < asio::yield_context
                            , void(sys::error_code, string)>::type;


### PR DESCRIPTION
This changes the content format (not the database index) so that users insert and retrieve raw arbitrary data from IPFS instead of just JSON (i.e. parsing the content is left to the user, see #9).